### PR TITLE
32 refactor code base

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,11 +13,13 @@ import Settings from './components/Settings';
 import Logging from './components/Logging';
 import Reports from './components/Reports';
 import { UserProvider } from './context/UserContext';
+import ApiTest from './components/ApiTest';
 
 function App() {
   return (
     <Provider store={store}>
       <UserProvider>
+        <ApiTest />
         <Router>
           <Routes>
             <Route path="/" element={<Login />} />

--- a/client/src/components/ApiTest.js
+++ b/client/src/components/ApiTest.js
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import axios from 'axios';
+
+const ApiCalls = () => {
+    useEffect(() => {
+        const fetchApiMessage = async () => {
+            try {
+                const response = await axios.get('http://localhost:5001/api');
+                console.log('API response:', response.data);
+            } catch (error) {
+                console.error('Error fetching api message:', error);
+            }
+        };
+
+        fetchApiMessage();
+    }, []);
+
+    return null;
+};
+
+export default ApiCalls;

--- a/client/src/components/Questionnaire.js
+++ b/client/src/components/Questionnaire.js
@@ -115,27 +115,46 @@ const Questionnaire = () => {
   };
 
 
+  // const handleMedicationChange = async (e) => {
+  //   const query = e.target.value;
+  //   setMedications(query);
+
+  //   if (query.length > 2) {
+  //     try {
+  //       const response = await axios.get(`https://api.fda.gov/drug/label.json?search=openfda.brand_name:${query}*&limit=10`);
+  //       setMedicationSuggestions(response.data.results.map(result => result.openfda.brand_name[0]));
+  //     } catch (error) {
+  //       if (error.response && error.response.status === 404) {
+  //         // console.error('No matches found for the query:', query);
+  //         setMedicationSuggestions([]);
+  //       } else {
+  //         console.error('Error fetching medication data:', error);
+  //       }
+  //     }
+  //   } else {
+  //     setMedicationSuggestions([]);
+  //   }
+  // };
+
   const handleMedicationChange = async (e) => {
     const query = e.target.value;
     setMedications(query);
-
+    
+    
     if (query.length > 2) {
       try {
-        const response = await axios.get(`https://api.fda.gov/drug/label.json?search=openfda.brand_name:${query}*&limit=10`);
-        setMedicationSuggestions(response.data.results.map(result => result.openfda.brand_name[0]));
+        const response = await axios.get(`http://localhost:5001/api/medications?q=${query}`);
+        setMedicationSuggestions(response.data);
       } catch (error) {
-        if (error.response && error.response.status === 404) {
-          // console.error('No matches found for the query:', query);
-          setMedicationSuggestions([]);
-        } else {
-          console.error('Error fetching medication data:', error);
-        }
+        console.error('Error fetching medication data:', error);
+        setMedicationSuggestions([]);
       }
     } else {
       setMedicationSuggestions([]);
     }
   };
-  
+
+
   const handleMedicationSelect = (medication) => {
     setMedications(medication);
     setMedicationSuggestions([]);

--- a/client/src/components/Questionnaire.js
+++ b/client/src/components/Questionnaire.js
@@ -114,32 +114,9 @@ const Questionnaire = () => {
     setCurrentQuestion(currentQuestion - 1);
   };
 
-
-  // const handleMedicationChange = async (e) => {
-  //   const query = e.target.value;
-  //   setMedications(query);
-
-  //   if (query.length > 2) {
-  //     try {
-  //       const response = await axios.get(`https://api.fda.gov/drug/label.json?search=openfda.brand_name:${query}*&limit=10`);
-  //       setMedicationSuggestions(response.data.results.map(result => result.openfda.brand_name[0]));
-  //     } catch (error) {
-  //       if (error.response && error.response.status === 404) {
-  //         // console.error('No matches found for the query:', query);
-  //         setMedicationSuggestions([]);
-  //       } else {
-  //         console.error('Error fetching medication data:', error);
-  //       }
-  //     }
-  //   } else {
-  //     setMedicationSuggestions([]);
-  //   }
-  // };
-
   const handleMedicationChange = async (e) => {
     const query = e.target.value;
     setMedications(query);
-    
     
     if (query.length > 2) {
       try {
@@ -153,7 +130,6 @@ const Questionnaire = () => {
       setMedicationSuggestions([]);
     }
   };
-
 
   const handleMedicationSelect = (medication) => {
     setMedications(medication);
@@ -238,27 +214,34 @@ const Questionnaire = () => {
     }
   }
 
-  /*
-  const toggleCondition = (condition) => {
-    setConditions((prevConditions) =>
-      prevConditions.includes(condition)
-        ? prevConditions.filter((c) => c !== condition)
-        : [...prevConditions, condition]
-    );
-  };
-  */
+  // useEffect(() => {
+  //   if (familyConditionInput.length > 2) {
+  //     const fetchFamilyConditions = async () => {
+  //       try {
+  //         const response = await axios.get(`https://clinicaltables.nlm.nih.gov/api/conditions/v3/search?terms=${familyConditionInput}&maxList=10`);
+  //         if (response.data && Array.isArray(response.data[3])) {
+  //           setFamilyConditionSuggestions(response.data[3]);
+  //         } else {
+  //           console.error('Unexpected response structure:', response.data);
+  //           setFamilyConditionSuggestions([]);
+  //         }
+  //       } catch (error) {
+  //         console.error('Error fetching family condition data:', error);
+  //         setFamilyConditionSuggestions([]);
+  //       }
+  //     };
+  //     fetchFamilyConditions();
+  //   } else {
+  //     setFamilyConditionSuggestions([]);
+  //   }
+  // }, [familyConditionInput]);
 
   useEffect(() => {
     if (familyConditionInput.length > 2) {
       const fetchFamilyConditions = async () => {
         try {
-          const response = await axios.get(`https://clinicaltables.nlm.nih.gov/api/conditions/v3/search?terms=${familyConditionInput}&maxList=10`);
-          if (response.data && Array.isArray(response.data[3])) {
-            setFamilyConditionSuggestions(response.data[3]);
-          } else {
-            console.error('Unexpected response structure:', response.data);
-            setFamilyConditionSuggestions([]);
-          }
+          const response = await axios.get(`http://localhost:5001/api/conditions?q=${familyConditionInput}`);
+          setFamilyConditionSuggestions(response.data);
         } catch (error) {
           console.error('Error fetching family condition data:', error);
           setFamilyConditionSuggestions([]);
@@ -270,6 +253,25 @@ const Questionnaire = () => {
     }
   }, [familyConditionInput]);
 
+  useEffect(() => {
+
+    if (conditionInput.length > 2) {
+      const fetchConditions = async () => {
+        try {
+          const response = await axios.get(`http://localhost:5001/api/conditions?q=${conditionInput}`);
+          setConditionSuggestions(response.data);
+        } catch (error) {
+          console.error('Error fetching condition data:', error);
+          setConditionSuggestions([]);
+        }
+      };
+      fetchConditions();
+    } else {
+      setConditionSuggestions([]);
+    }
+
+  }, [conditionInput]);
+
   const handleAddFamilyCondition = () => {
     if (familyConditionInput && !familyConditions.includes(familyConditionInput)) {
       setFamilyConditions([...familyConditions, familyConditionInput]);
@@ -280,14 +282,6 @@ const Questionnaire = () => {
   const handleRemoveFamilyCondition = (index) => {
     setFamilyConditions(familyConditions.filter((_, i) => i !== index));
   };
-
-  // const toggleFamilyCondition = (familyCondition) => {
-  //   setFamilyConditions((prevfamilyConditions) =>
-  //     prevfamilyConditions.includes(familyCondition)
-  //       ? prevfamilyConditions.filter((fc) => fc !== familyCondition)
-  //       : [...prevfamilyConditions, familyCondition]
-  //   );
-  // };
 
   const handleAddAllergy = () => {
     if (allergies && !addedAllergies.includes(allergies)) {

--- a/client/src/components/Questionnaire.js
+++ b/client/src/components/Questionnaire.js
@@ -214,28 +214,6 @@ const Questionnaire = () => {
     }
   }
 
-  // useEffect(() => {
-  //   if (familyConditionInput.length > 2) {
-  //     const fetchFamilyConditions = async () => {
-  //       try {
-  //         const response = await axios.get(`https://clinicaltables.nlm.nih.gov/api/conditions/v3/search?terms=${familyConditionInput}&maxList=10`);
-  //         if (response.data && Array.isArray(response.data[3])) {
-  //           setFamilyConditionSuggestions(response.data[3]);
-  //         } else {
-  //           console.error('Unexpected response structure:', response.data);
-  //           setFamilyConditionSuggestions([]);
-  //         }
-  //       } catch (error) {
-  //         console.error('Error fetching family condition data:', error);
-  //         setFamilyConditionSuggestions([]);
-  //       }
-  //     };
-  //     fetchFamilyConditions();
-  //   } else {
-  //     setFamilyConditionSuggestions([]);
-  //   }
-  // }, [familyConditionInput]);
-
   useEffect(() => {
     if (familyConditionInput.length > 2) {
       const fetchFamilyConditions = async () => {

--- a/server/app.js
+++ b/server/app.js
@@ -11,7 +11,9 @@ const cors = require('cors');
 
 // Middleware
 app.use(bodyParser.json());
-app.use(cors());
+app.use(cors({
+    origin: 'http://localhost:3000'
+}));
 
 // Routes
 const apiRoutes = require('./routes/api');

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,9 +1,30 @@
 const express = require('express');
+const axios = require('axios');
 const router = express.Router();
 
 // example route
 router.get('/', (req, res) => {
   res.send('API is working');
 });
+
+//  new route for fda api call
+router.get('/medications', async (req, res) => {
+  
+  const query = req.query.q; //  get the query parameter from the request
+
+  if (!query || query.length <= 2) {
+    return res.status(400).json({ error: 'Query parameter must be longer than 2 characters' });
+  }
+
+  try {
+    const response = await axios.get(`https://api.fda.gov/drug/label.json?search=openfda.brand_name:${query}*&limit=10`);
+    const suggestions = response.data.results.map(results => results.openfda.brand_name[0]);
+    res.json(suggestions);
+  } catch (error) {
+    console.error('Error fetching medication data:', error);
+    res.status(500).json({ error: 'Error fetching medication data' })
+  }
+});
+
 
 module.exports = router;

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -26,5 +26,24 @@ router.get('/medications', async (req, res) => {
   }
 });
 
+//  new route for clinical conditions api call
+router.get('/conditions', async (req, res) => {
+
+  const query = req.query.q;
+
+  if (!query || query.length <= 2) {
+    return res.status(400).json({ error: 'Query parameter must be longer than 2 characters' });
+  }
+
+  try {
+    const response = await axios.get(`https://clinicaltables.nlm.nih.gov/api/conditions/v3/search?terms=${query}&maxList=10`);
+    const suggestions = response.data[3];
+    res.json(suggestions);
+  } catch (error) {
+    console.error('Error fetching condition data:', error);
+    res.status(500).json({ error: 'Error fetching condition data'});
+  }
+
+})
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -2,12 +2,9 @@
  *  @description    backend server using express, will handle http requests and responses
  *                  api endpoints where you can define routes or endpoints to handle requests
  */
-
-
-const express = require('express');
 const bodyParser = require('body-parser');
 
-const app = express();
+const app = require('./app');
 const PORT = process.env.PORT || 5001;
 
 app.listen(PORT, () => {


### PR DESCRIPTION
ApiTest.js may not be needed but if you want to test some internal calls to make external calls then that's the module to do it with, however it could be stored elsewhere instead of the components directory.

In general the 

`axios.get(http://localhost:5001/api/conditions?q=${familyConditionInput});` will call 

router.get('/conditions', async (req, res) => { // code  });

which calls the external api 

`axios.get(https://clinicaltables.nlm.nih.gov/api/conditions/v3/search?terms=${query}&maxList=10);`


same for `medications` and `familyConditions`